### PR TITLE
support pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
-/build
-/build-debug
-/build-debug-noalert
-/_backup
-/__pychache__
+build/
+build-debug/
+build-debug-noalert/
+dist/
+venv/
+_backup/
+_skbuild/
+__pychache__/
+*.egg-info/
 
 # binary
 metro
@@ -14,3 +18,6 @@ metro-debug-noalert
 /*.metro
 
 /test.*
+
+MANIFEST.in
+!CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18...3.22)
+project(metro)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_LINKER ${CMAKE_CXX_COMPILER})
+set(CMAKE_C_FLAGS "-O3 -Wall -Wextra -Wno-switch")
+set(CMAKE_CXX_FLAGS ${CMAKE_C_FLAGS})
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections")
+set(CMAKE_CXX_STANDARD 20)
+
+include_directories(include)
+file(GLOB_RECURSE SRC src/*.cpp)
+add_executable(${PROJECT_NAME} ${SRC})
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)

--- a/metrolang/__init__.py
+++ b/metrolang/__init__.py
@@ -1,0 +1,9 @@
+import os
+import subprocess
+import sys
+
+CMAKE_BIN_DIR = os.path.join(os.path.dirname(__file__), "bin")
+
+
+def metro():
+    raise SystemExit(subprocess.call([os.path.join(CMAKE_BIN_DIR, "metro")] + sys.argv[1:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "scikit-build>=0.13",
+    "cmake>=3.18",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from skbuild import setup
+
+setup(
+    name="metrolang",
+    version="0.7.7",
+    description="A Typed Script Language",
+    author="mugen1234",
+    url="https://github.com/mugen1234/metro",
+    license="MIT",
+    packages=["metrolang"],
+    cmake_install_dir="metrolang/bin",
+    entry_points={
+        "console_scripts": [
+            "metro=metrolang:metro"
+        ]
+    }
+)


### PR DESCRIPTION
pipコマンドでmetroバイナリをインストールできるようになりました．

```sh
cd path/to/metro
pip install .
```

上記変更に伴い，CMakeでのビルドにも対応しました．

```sh
mkdir build && cd build

# Ninjaでビルドする場合
cmake -G Ninja ..
cmake --build .

# Makefileでビルドする場合
cmake ..
make -j
```